### PR TITLE
Fix issue #35 - resourceReady not firing

### DIFF
--- a/src/ResourceLoader.ts
+++ b/src/ResourceLoader.ts
@@ -102,7 +102,7 @@ export class ResourceLoader {
 		loadResources(readyForLoad);
 		if (isEmpty(this.waitingResources) && isEmpty(this.pendingResources)) {
 			const event: CustomEvent = new CustomEvent(this.options.readyEvent);
-			document.dispatchEvent(event);
+			window.dispatchEvent(event);
 		}
 	}
 

--- a/src/fp/remove.ts
+++ b/src/fp/remove.ts
@@ -1,6 +1,6 @@
 import curry from './curry';
 
-const remove = (start: number, deleteCount: number, arr: ReadonlyArray<any>) => {
+const remove = (start: number, deleteCount: number, arr: Array<any>) => {
 	const newArr = [...arr];
 	newArr.splice(start, deleteCount);
 	return newArr;


### PR DESCRIPTION
Enable the parameter array to be mutated from splice by changing the interface to Array. Since on @biotope/boilerplate the eventListener is on the window object, I also dispatched the event to it. 