### PR TITLE
add to head instead of body, make css and js file detection failsafe

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,22 +3,22 @@ import { ResourceLoaderOptions } from './types';
 
 window['resourceLoader'] = (options: ResourceLoaderOptions) => {
     const cssHandler = {
-        match: (options) => options.resource.path.indexOf('.css') > -1,
+        match: (options) => (options.resource.path.indexOf('.css') >= -1 && options.resource.path.indexOf('.css') >= options.resource.path.length -4),
         handle: (options) => {
             const style = document.createElement('link');
             style.rel = 'stylesheet';
             style.href = options.resource.path;
-            document.body.append(style);
+            document.head.append(style);
         }
     }
 
     const jsHandler = {
-        match: (options) => options.resource.path.indexOf('.js') > -1,
+        match: (options) => options.resource.path.indexOf('.js') > -1 && options.resource.path.indexOf('.js') >= options.resource.path.length -4,
         handle: (options) => {
             const script = document.createElement('script');
             script.src = options.resource.path;
             script.async = true;
-            document.body.append(script);
+            document.head.append(script);
         }
     }
 


### PR DESCRIPTION
fix css and js detection to not detect midpath names like /bla.css/xyz/